### PR TITLE
Job normalization in ES, second try

### DIFF
--- a/api/v1/endpoints.py
+++ b/api/v1/endpoints.py
@@ -357,50 +357,109 @@ class JobTitleNormalizeEndpoint(Resource):
 
     def get(self):
         """GET operation for the endpoint class.
+
         Returns: 
             A normalized version of a specified job title.
+
         """
         args = request.args
-        
+
         if args is not None:
+            if 'limit' in args.keys():
+                try:
+                    limit = int(args['limit'])
+                    if limit < 0:
+                        return create_error('Limit must be a positive integer.', 400)
+                    if limit > 10:
+                        return create_error('Limit has a maximum of 10.', 400)
+                except:
+                    return create_error('Limit must be an integer', 400)
+            else:
+                limit = 1
+
             if 'job_title' in args.keys():
                 search_string = str(args['job_title'])
             else:
                 return create_error('Invalid parameter specified for job title normalization', 400)
 
-            if 'limit' in args.keys():
-                try:
-                    suggestion_limit = int(args['limit'])
-                except:
-                    suggestion_limit = 1
-            else:
-                suggestion_limit = 1
+            indexed_field = 'canonicaltitle'
 
-            search_string = search_string.replace('"','').strip()
+            request_body = {
+                "size": limit*10, # give us a buffer to remove duplicates
+                "fields": [indexed_field],
+                "query" : {
+                    "bool": {
+                        "should": [
+                            { "multi_match": {
+                                "query": search_string,
+                                "fields": ['{}^5'.format(indexed_field), "occupation", "jobtitle"]
+                            } },
+                            { "terms": {
+                                "jobdesc": search_string.split(' ')
+                            } }
+                        ]
+                    }
+                }
+            }
+
+            response = es.search(index='job_normalize', body=request_body)
+            results = response['hits']['hits']
+            if len(results) == 0:
+                return create_error('No normalized job titles found', 404)
+
+            def normalize(value):
+                minimum = 0.0
+                maximum = 10.0
+                if value < minimum:
+                    return 0.0
+                elif value > maximum:
+                    return 1.0
+                else:
+                    return (value - minimum) / (maximum - minimum)
+
+            # take unique titles until reaching the limit
+            distinct_titles = set()
+            titles = []
+            num_distinct_titles = 0
+            for result in results:
+                if num_distinct_titles >= limit:
+                    break
+                if 'fields' not in result or indexed_field not in result['fields']:
+                    continue
+                title = result['fields'][indexed_field][0]
+                if title in distinct_titles:
+                    continue
+                distinct_titles.add(title)
+                titles.append({
+                    'title': title,
+                    'score': normalize(result['_score']),
+                    'uuid': str(hashlib.md5(title).hexdigest())
+                })
+                num_distinct_titles += 1
+
             all_suggestions = []
-            
-            result = JobUnusualTitle.query.filter(JobUnusualTitle.title.contains(search_string.lower())).first()
 
-            if result is None:
-                return create_error('No normalized job titles found', 404)                
+            category_fetch_stmt = JobAlternateTitle.__table__.select(
+                JobAlternateTitle.uuid.in_([title['uuid'] for title in titles])
+            )
 
-            alt_titles = JobAlternateTitle.query.filter_by(job_uuid = result.job_uuid).all()
-            if suggestion_limit > len(alt_titles):
-                suggestion_limit = len(alt_titles)
+            category_fetch_results = db.engine.execute(category_fetch_stmt)
+            category_lookup = { row[0]: row[3] for row in category_fetch_results }
 
-            for i in range(0, suggestion_limit):
+            for row in titles:
                 suggestion = OrderedDict()
-                chosen_title = random.randint(0, len(alt_titles) - 1)
-                suggestion['uuid'] = alt_titles[chosen_title].uuid
-                suggestion['title'] = alt_titles[chosen_title].title
-                suggestion['relevance_score'] = fake_relevance_score() 
-                suggestion['parent_uuid'] = alt_titles[chosen_title].job_uuid
+                suggestion['uuid'] = row['uuid']
+                suggestion['title'] = row['title']
+                suggestion['relevance_score'] = row['score']
+                if row['uuid'] in category_lookup:
+                    suggestion['parent_uuid'] = category_lookup[row['uuid']]
+                else:
+                    suggestion['parent_uuid'] = ''
                 all_suggestions.append(suggestion)
 
             return create_response(sorted(all_suggestions, key=lambda k: k['relevance_score'], reverse=True), 200)
         else:
-            return create_error('No normalized job titles found', 404) 
-
+            return create_error('No normalized job titles found', 404)
 
 class JobTitleFromONetCodeEndpoint(Resource):
     """Job Title From O*NET SOC Code Endpoint Class"""


### PR DESCRIPTION
Using the new endpoint. I tested this one out on 'staging', and the uuids that come back, both job and parent, correctly map to values we can look up in the jobs/{id} endpoint (and make sense when you look them up!).