### PR TITLE
Expose skill_type column

### DIFF
--- a/api/v1/endpoints.py
+++ b/api/v1/endpoints.py
@@ -241,6 +241,7 @@ class AllSkillsEndpoint(Resource):
                 skill_response = OrderedDict()
                 skill_response['uuid'] = skill.uuid
                 skill_response['name'] = skill.skill_name
+                skill_response['type'] = skill.ksa_type
                 skill_response['description'] = skill.description
                 skill_response['onet_element_id'] = skill.onet_element_id
                 skill_response['normalized_skill_name'] = skill.nlp_a
@@ -627,6 +628,7 @@ class AssociatedSkillsForJobEndpoint(Resource):
                     skill_desc = SkillMaster.query.filter_by(uuid = result.skill_uuid).first()
                     skill['skill_uuid'] = result.skill_uuid
                     skill['skill_name'] = skill_desc.skill_name
+                    skill['skill_type'] = skill_desc.ksa_type
                     skill['description'] = skill_desc.description
                     skill['normalized_skill_name'] = skill_desc.nlp_a
                     skill['importance'] = result.importance
@@ -752,6 +754,7 @@ class AssociatedSkillForSkillEndpoint(Resource):
                         output = OrderedDict()
                         output['uuid'] = skill.uuid
                         output['skill_name'] = skill.skill_name
+                        output['skill_type'] = skill.ksa_type
                         output['normalized_skill_name'] = skill.nlp_a
                         all_skills['skills'].append(output)
                     return create_response(all_skills, 200)

--- a/api/v1/models/skills_master.py
+++ b/api/v1/models/skills_master.py
@@ -9,13 +9,15 @@ class SkillMaster(db.Model):
 
     uuid = db.Column(db.String, primary_key=True)
     skill_name = db.Column(db.String)
+    ksa_type = db.Column(db.String)
     onet_element_id = db.Column(db.String)
     description = db.Column(db.String)
     nlp_a = db.Column(db.String)
 
-    def __init__(self, uuid, skill_name, onet_element_id, description, nlp_a):
+    def __init__(self, uuid, skill_name, ksa_type, onet_element_id, description, nlp_a):
         self.uuid = uuid
         self.skill_name = skill_name
+        self.ksa_type = ksa_type
         self.onet_element_id = onet_element_id
         self.description = description
         self.nlp_a = nlp_a


### PR DESCRIPTION
Resolves #27 
With the work merged in 
https://github.com/workforce-data-initiative/skills-ml/pull/32

We can now expose the skill type when listing details about the skill (whenever we are showing the skill name, as opposed to just an id, basically).

This shows up in the all skills endpoint, associated skills for a job, and associated skills for a skill.