### PR TITLE
Strip leading/trailing spaces from custom header keys and values

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -75,7 +75,7 @@ def create_response(data, status, custom_headers=None):
     if custom_headers is not None:
         for custom_header in custom_headers:
             header = custom_header.strip().split('=')
-            response.headers[header[0]] = header[1]
+            response.headers[header[0].strip()] = header[1].strip()
 
     return response
 


### PR DESCRIPTION
This fixes a bug observed after a system upgrade. I'm not sure exactly the cause but maybe a new Apache is more strict about these headers. Basically, all of the endpoints which included an X-Total-Count were 500-ing because of the extra spaces.